### PR TITLE
Fixed underflow error for pull req

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1127,7 +1127,7 @@ pub mod grid {
                 new_organisms.push(Organism {
                     id: None,
                     cells: new_organism_cells,
-                    energy: organism.energy - 1,
+                    energy: if organism.energy > 0 {organism.energy-1} else {0},
                     able_to_move: organism.able_to_move,
                 });
             }


### PR DESCRIPTION
went under zero and would cause following error:
thread 'tokio-runtime-worker' panicked at src\main.rs:1130:29:
attempt to subtract with overflow
[src\main.rs:382:21] error = JoinFailed